### PR TITLE
Add --imap-folder Flag

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,10 @@ pub struct Configuration {
     #[arg(long, env, default_value_t = 993)]
     pub imap_port: u16,
 
+    /// IMAP folder with the DMARC reports
+    #[arg(long, env, default_value = "INBOX")]
+    pub imap_folder: String,
+
     /// TCP connection timeout for IMAP server in seconds
     #[arg(long, env, default_value_t = 10)]
     pub imap_timeout: u64,

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -73,16 +73,17 @@ pub async fn get_mails(config: &Configuration) -> Result<HashMap<u32, Mail>> {
         .context("Failed to log in and create IMAP session")?;
     debug!("IMAP login successful");
 
+    let imap_folder = &config.imap_folder;
     let mailbox = session
-        .select("INBOX")
+        .select(imap_folder)
         .await
-        .context("Failed to select inbox")?;
-    debug!("Selected INBOX successfully");
+        .context("Failed to select {imap_folder} folder")?;
+    debug!("Selected {imap_folder} folder successfully");
 
     // Get metadata for all all mails and filter by size
     let mut mails = HashMap::new();
     let mut size_filtered_uids = Vec::new();
-    debug!("Number of mails in INBOX: {}", mailbox.exists);
+    debug!("Number of mails in {imap_folder} folder: {}", mailbox.exists);
     if mailbox.exists > 0 {
         let sequence = format!("1:{}", mailbox.exists);
         let mut stream = session

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -83,7 +83,10 @@ pub async fn get_mails(config: &Configuration) -> Result<HashMap<u32, Mail>> {
     // Get metadata for all all mails and filter by size
     let mut mails = HashMap::new();
     let mut size_filtered_uids = Vec::new();
-    debug!("Number of mails in {imap_folder} folder: {}", mailbox.exists);
+    debug!(
+        "Number of mails in {imap_folder} folder: {}",
+        mailbox.exists
+    );
     if mailbox.exists > 0 {
         let sequence = format!("1:{}", mailbox.exists);
         let mut stream = session


### PR DESCRIPTION
Add --imap-folder flag to optionally retrieve DMARC reports from a folder other than INBOX, which remains the default.