### PR TITLE
EXPOSE port 8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,5 @@ RUN strip /usr/src/target/release/dmarc-report-viewer
 # Build final minimal image with only the binary
 FROM scratch
 COPY --from=builder /usr/src/target/release/dmarc-report-viewer /
+EXPOSE 8080
 CMD ["./dmarc-report-viewer"]


### PR DESCRIPTION
This adds an [EXPOSE](https://docs.docker.com/reference/dockerfile/#expose) directive on the default port, which allows containers like Traefik and friends to discover an appropriate port without any further configuration.