### PR TITLE
Add support for TLS-RPT reports

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -3,6 +3,7 @@ mod ips;
 mod mails;
 mod static_files;
 mod summary;
+mod tlsrpt_reports;
 
 use crate::config::Configuration;
 use crate::state::AppState;
@@ -41,6 +42,9 @@ pub async fn run_http_server(config: &Configuration, state: Arc<Mutex<AppState>>
         .route("/dmarc-reports/{id}", get(dmarc_reports::single_handler))
         .route("/dmarc-reports/{id}/json", get(dmarc_reports::json_handler))
         .route("/dmarc-reports/{id}/xml", get(dmarc_reports::xml_handler))
+        .route("/tlsrpt-reports", get(tlsrpt_reports::list_handler))
+        .route("/tlsrpt-reports/{id}", get(tlsrpt_reports::single_handler))
+        .route("/tlsrpt-reports/{id}/json", get(tlsrpt_reports::json_handler))
         .route("/ips/{ip}/dns", get(ips::to_dns_handler))
         .route("/ips/{ip}/location", get(ips::to_location_handler))
         .route("/ips/{ip}/whois", get(ips::to_whois_handler))

--- a/src/http/static_files.rs
+++ b/src/http/static_files.rs
@@ -76,9 +76,19 @@ const STATIC_FILES: &[StaticFile] = &[
         _data: include_bytes!("../../ui/components/dmarc-report.js"),
     },
     StaticFile {
+        http_path: "/components/tlsrpt-report.js",
+        file_path: "ui/components/tlsrpt-report.js",
+        _data: include_bytes!("../../ui/components/tlsrpt-report.js"),
+    },
+    StaticFile {
         http_path: "/components/dmarc-reports.js",
         file_path: "ui/components/dmarc-reports.js",
         _data: include_bytes!("../../ui/components/dmarc-reports.js"),
+    },
+    StaticFile {
+        http_path: "/components/tlsrpt-reports.js",
+        file_path: "ui/components/tlsrpt-reports.js",
+        _data: include_bytes!("../../ui/components/tlsrpt-reports.js"),
     },
     StaticFile {
         http_path: "/components/mails.js",
@@ -99,6 +109,11 @@ const STATIC_FILES: &[StaticFile] = &[
         http_path: "/components/dmarc-report-table.js",
         file_path: "ui/components/dmarc-report-table.js",
         _data: include_bytes!("../../ui/components/dmarc-report-table.js"),
+    },
+    StaticFile {
+        http_path: "/components/tlsrpt-report-table.js",
+        file_path: "ui/components/tlsrpt-report-table.js",
+        _data: include_bytes!("../../ui/components/tlsrpt-report-table.js"),
     },
 ];
 

--- a/src/http/summary.rs
+++ b/src/http/summary.rs
@@ -1,5 +1,6 @@
 use crate::dmarc::{DkimResultType, DmarcResultType, SpfResultType};
-use crate::state::{AppState, DmarcReportWithUid};
+use crate::state::{AppState, DmarcReportWithUid, TlsRptReportWithUid};
+use crate::tlsrpt::{PolicyType, FailureResultType, TlsRptResultType};
 use axum::extract::{Query, State};
 use axum::response::IntoResponse;
 use axum::Json;
@@ -49,7 +50,9 @@ pub async fn handler(
     let summary = Summary::new(
         guard.mails.len(),
         guard.xml_files,
+        guard.json_files,
         &guard.dmarc_reports,
+        &guard.tlsrpt_reports,
         guard.last_update,
         time_span,
         filters.domain,
@@ -58,24 +61,18 @@ pub async fn handler(
 }
 
 #[derive(Serialize, Default, Clone)]
-pub struct Summary {
-    /// Number of mails from IMAP inbox
-    pub mails: usize,
-
+pub struct DmarcSummary {
     /// Number of XML files found in mails from IMAPinbox
-    pub xml_files: usize,
+    pub files: usize,
 
     /// Number of successfully parsed DMARC reports XML files found in IMAP inbox
-    pub dmarc_reports: usize,
+    pub reports: usize,
 
-    /// Unix timestamp with time of last update
-    pub last_update: u64,
+    /// Map of organizations with number of corresponding DMARC reports
+    pub orgs: HashMap<String, usize>,
 
-    /// Map of organizations with number of corresponding reports
-    pub dmarc_orgs: HashMap<String, usize>,
-
-    /// Map of domains with number of corresponding reports
-    pub dmarc_domains: HashMap<String, usize>,
+    /// Map of domains with number of corresponding DMARC reports
+    pub domains: HashMap<String, usize>,
 
     /// Map of DMARC SPF policy evaluation results
     pub spf_policy_results: HashMap<DmarcResultType, usize>,
@@ -90,22 +87,101 @@ pub struct Summary {
     pub dkim_auth_results: HashMap<DkimResultType, usize>,
 }
 
+#[derive(Serialize, Default, Clone)]
+pub struct TlsRptSummary {
+    /// Number of JSON files found in mails from IMAP inbox
+    pub files: usize,
+
+    /// Number of successfully parsed TLS-RPT reports JSON files found in IMAP inbox
+    pub reports: usize,
+
+    /// Map of organizations with number of corresponding TLS-RPT reports
+    pub orgs: HashMap<String, usize>,
+
+    /// Map of domains with number of corresponding TLS-RPT policy evaluations
+    pub domains: HashMap<String, usize>,
+
+    /// Map of TLS-RPT policy types
+    pub policy_types: HashMap<PolicyType, usize>,
+
+    /// Map of TLS-RPT STS policy evaluation results
+    pub sts_policy_results: HashMap<TlsRptResultType, usize>,
+
+    /// Map of TLS-RPT TLSA policy evaluation results
+    pub tlsa_policy_results: HashMap<TlsRptResultType, usize>,
+
+    /// Map of TLS-RPT STS failure results
+    pub sts_failure_types: HashMap<FailureResultType, usize>,
+
+    /// Map of TLS-RPT TLSA failure results
+    pub tlsa_failure_types: HashMap<FailureResultType, usize>,
+}
+
+
+#[derive(Serialize, Default, Clone)]
+pub struct Summary {
+    /// Number of mails from IMAP inbox
+    pub mails: usize,
+
+    /// Unix timestamp with time of last update
+    pub last_update: u64,
+
+    /// Information about DMARC reports
+    pub dmarc: DmarcSummary,
+
+    /// Information about TLS-RPT reports
+    pub tlsrpt: TlsRptSummary,
+}
+
 impl Summary {
     pub fn new(
         mails: usize,
         xml_files: usize,
+        json_files: usize,
         dmarc_reports: &HashMap<String, DmarcReportWithUid>,
+        tlsrpt_reports: &HashMap<String, TlsRptReportWithUid>,
         last_update: u64,
         time_span: Option<Duration>,
         domain: Option<String>,
     ) -> Self {
-        let mut dmarc_orgs: HashMap<String, usize> = HashMap::new();
-        let mut dmarc_domains = HashMap::new();
-        let mut spf_policy_results: HashMap<DmarcResultType, usize> = HashMap::new();
-        let mut dkim_policy_results: HashMap<DmarcResultType, usize> = HashMap::new();
-        let mut spf_auth_results: HashMap<SpfResultType, usize> = HashMap::new();
-        let mut dkim_auth_results: HashMap<DkimResultType, usize> = HashMap::new();
+        let dmarc_orgs: HashMap<String, usize> = HashMap::new();
+        let dmarc_domains = HashMap::new();
+        let spf_policy_results: HashMap<DmarcResultType, usize> = HashMap::new();
+        let dkim_policy_results: HashMap<DmarcResultType, usize> = HashMap::new();
+        let spf_auth_results: HashMap<SpfResultType, usize> = HashMap::new();
+        let dkim_auth_results: HashMap<DkimResultType, usize> = HashMap::new();
+        let mut dmarc = DmarcSummary {
+            files: xml_files,
+            reports: dmarc_reports.len(),
+            orgs: dmarc_orgs,
+            domains: dmarc_domains,
+            spf_policy_results,
+            dkim_policy_results,
+            spf_auth_results,
+            dkim_auth_results,
+        };
+
+        let tlsrpt_orgs: HashMap<String, usize> = HashMap::new();
+        let tlsrpt_domains = HashMap::new();
+        let policy_types: HashMap<PolicyType, usize> = HashMap::new();
+        let sts_policy_results: HashMap<TlsRptResultType, usize> = HashMap::new();
+        let tlsa_policy_results: HashMap<TlsRptResultType, usize> = HashMap::new();
+        let sts_failure_types: HashMap<FailureResultType, usize> = HashMap::new();
+        let tlsa_failure_types: HashMap<FailureResultType, usize> = HashMap::new();
+        let mut tlsrpt = TlsRptSummary {
+            files: json_files,
+            reports: tlsrpt_reports.len(),
+            orgs: tlsrpt_orgs,
+            domains: tlsrpt_domains,
+            policy_types: policy_types,
+            sts_policy_results,
+            tlsa_policy_results,
+            sts_failure_types,
+            tlsa_failure_types,
+        };
+
         let threshold = time_span.map(|d| (Utc::now() - d).timestamp() as u64);
+        let threshold_datetime = time_span.map(|d| Utc::now() - d);
         for DmarcReportWithUid { report, .. } in dmarc_reports.values() {
             if let Some(threshold) = threshold {
                 if report.report_metadata.date_range.end < threshold {
@@ -118,61 +194,122 @@ impl Summary {
                 }
             }
             let domain = report.policy_published.domain.clone();
-            if let Some(entry) = dmarc_domains.get_mut(&domain) {
+            if let Some(entry) = dmarc.domains.get_mut(&domain) {
                 *entry += 1;
             } else {
-                dmarc_domains.insert(domain, 1);
+                dmarc.domains.insert(domain, 1);
             }
             let org = report.report_metadata.org_name.clone();
-            if let Some(entry) = dmarc_orgs.get_mut(&org) {
+            if let Some(entry) = dmarc.orgs.get_mut(&org) {
                 *entry += 1;
             } else {
-                dmarc_orgs.insert(org, 1);
+                dmarc.orgs.insert(org, 1);
             }
             for record in &report.record {
                 for r in &record.auth_results.spf {
-                    if let Some(entry) = spf_auth_results.get_mut(&r.result) {
+                    if let Some(entry) = dmarc.spf_auth_results.get_mut(&r.result) {
                         *entry += record.row.count;
                     } else {
-                        spf_auth_results.insert(r.result.clone(), record.row.count);
+                        dmarc.spf_auth_results.insert(r.result.clone(), record.row.count);
                     }
                 }
                 if let Some(vec) = &record.auth_results.dkim {
                     for r in vec {
-                        if let Some(entry) = dkim_auth_results.get_mut(&r.result) {
+                        if let Some(entry) = dmarc.dkim_auth_results.get_mut(&r.result) {
                             *entry += record.row.count;
                         } else {
-                            dkim_auth_results.insert(r.result.clone(), record.row.count);
+                            dmarc.dkim_auth_results.insert(r.result.clone(), record.row.count);
                         }
                     }
                 }
                 if let Some(result) = &record.row.policy_evaluated.spf {
-                    if let Some(entry) = spf_policy_results.get_mut(result) {
+                    if let Some(entry) = dmarc.spf_policy_results.get_mut(result) {
                         *entry += record.row.count;
                     } else {
-                        spf_policy_results.insert(result.clone(), record.row.count);
+                        dmarc.spf_policy_results.insert(result.clone(), record.row.count);
                     }
                 }
                 if let Some(result) = &record.row.policy_evaluated.dkim {
-                    if let Some(entry) = dkim_policy_results.get_mut(result) {
+                    if let Some(entry) = dmarc.dkim_policy_results.get_mut(result) {
                         *entry += record.row.count;
                     } else {
-                        dkim_policy_results.insert(result.clone(), record.row.count);
+                        dmarc.dkim_policy_results.insert(result.clone(), record.row.count);
+                    }
+                }
+            }
+        }
+        for TlsRptReportWithUid { report, .. } in tlsrpt_reports.values() {
+            if let Some(threshold_datetime) = threshold_datetime {
+                if report.date_range.end_datetime < threshold_datetime {
+                    continue;
+                }
+            }
+            if let Some(domain) = &domain {
+                if report.policies.iter().all(|p| p.policy.policy_domain != *domain) {
+                    continue;
+                }
+            }
+            let org = report.organization_name.clone();
+            if let Some(entry) = tlsrpt.orgs.get_mut(&org) {
+                *entry += 1;
+            } else {
+                tlsrpt.orgs.insert(org, 1);
+            }
+            for policy_result in report.policies.iter() {
+                let domain = policy_result.policy.policy_domain.clone();
+                if let Some(entry) = tlsrpt.domains.get_mut(&domain) {
+                    *entry += 1;
+                } else {
+                    tlsrpt.domains.insert(domain, 1);
+                }
+                if let Some(entry) = tlsrpt.policy_types.get_mut(&policy_result.policy.policy_type) {
+                    *entry += 1;
+                } else {
+                    tlsrpt.policy_types.insert(policy_result.policy.policy_type.clone(), 1);
+                }
+                let policy_results;
+                let failure_types;
+                match &policy_result.policy.policy_type {
+                    PolicyType::Sts => {
+                        policy_results = &mut tlsrpt.sts_policy_results;
+                        failure_types = &mut tlsrpt.sts_failure_types;
+                    }
+                    PolicyType::Tlsa => {
+                        policy_results = &mut tlsrpt.tlsa_policy_results;
+                        failure_types = &mut tlsrpt.tlsa_failure_types;
+                    }
+                    PolicyType::NoPolicyFound => {
+                        continue;
+                    }
+                }
+                let success_count = policy_result.summary.total_successful_session_count;
+                let failure_count = policy_result.summary.total_failure_session_count;
+                if let Some(entry) = policy_results.get_mut(&TlsRptResultType::Successful) {
+                    *entry += success_count;
+                } else {
+                    policy_results.insert(TlsRptResultType::Successful, success_count);
+                }
+                if let Some(entry) = policy_results.get_mut(&TlsRptResultType::Failure) {
+                    *entry += failure_count;
+                } else {
+                    policy_results.insert(TlsRptResultType::Failure, failure_count);
+                }
+                if let Some(failure_details) = &policy_result.failure_details {
+                    for failure_detail in failure_details {
+                        if let Some(entry) = failure_types.get_mut(&failure_detail.result_type) {
+                            *entry += failure_detail.failed_session_count;
+                        } else {
+                            failure_types.insert(failure_detail.result_type.clone(), failure_detail.failed_session_count);
+                        }
                     }
                 }
             }
         }
         Self {
             mails,
-            xml_files,
             last_update,
-            dmarc_reports: dmarc_reports.len(),
-            dmarc_orgs,
-            dmarc_domains,
-            spf_policy_results,
-            dkim_policy_results,
-            spf_auth_results,
-            dkim_auth_results,
+            dmarc,
+            tlsrpt,
         }
     }
 }

--- a/src/http/tlsrpt_reports.rs
+++ b/src/http/tlsrpt_reports.rs
@@ -1,0 +1,209 @@
+use crate::state::AppState;
+use crate::tlsrpt::PolicyType;
+use crate::tlsrpt::Report;
+use axum::extract::Path;
+use axum::extract::Query;
+use axum::extract::State;
+use axum::http::header;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use chrono::DateTime;
+use chrono::Utc;
+use serde::Deserialize;
+use serde::Serialize;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+#[derive(Serialize)]
+struct ReportHeader {
+    hash: String,
+    id: String,
+    org: String,
+    domains: Vec<String>,
+    date_begin: DateTime<Utc>,
+    date_end: DateTime<Utc>,
+    records: usize,
+    flagged_sts: bool,
+    flagged_tlsa: bool,
+    flagged: bool,
+}
+
+impl ReportHeader {
+    pub fn from_report(hash: &str, report: &Report) -> Self {
+        let (flagged_sts, flagged_tlsa) = Self::report_is_flagged(report);
+        Self {
+            hash: hash.to_string(),
+            id: report.report_id.clone(),
+            org: report.organization_name.clone(),
+            domains: {
+                let mut domains = report
+                    .policies
+                    .iter()
+                    .map(|p| p.policy.policy_domain.clone())
+                    .collect::<Vec<String>>();
+                domains.sort();
+                domains.dedup();
+                domains
+            },
+            date_begin: report.date_range.start_datetime,
+            date_end: report.date_range.end_datetime,
+            records: report.policies.len(),
+            flagged: flagged_sts || flagged_tlsa,
+            flagged_sts,
+            flagged_tlsa,
+        }
+    }
+
+    /// Checks if the report has STS or TLSA issues
+    fn report_is_flagged(report: &Report) -> (bool, bool) {
+        let mut sts_flagged = false;
+        let mut tlsa_flagged = false;
+        for policy_result in &report.policies {
+            if policy_result.summary.total_failure_session_count > 0 {
+                match &policy_result.policy.policy_type {
+                    PolicyType::Sts => {
+                        sts_flagged = true;
+                    }
+                    PolicyType::Tlsa => {
+                        tlsa_flagged = true;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        (sts_flagged, tlsa_flagged)
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ReportFilters {
+    uid: Option<u32>,
+    flagged: Option<bool>,
+    flagged_sts: Option<bool>,
+    flagged_tlsa: Option<bool>,
+    domain: Option<String>,
+    org: Option<String>,
+}
+
+impl ReportFilters {
+    fn url_decode(&self) -> Self {
+        Self {
+            uid: self.uid,
+            flagged: self.flagged,
+            flagged_sts: self.flagged_sts,
+            flagged_tlsa: self.flagged_tlsa,
+            domain: self
+                .domain
+                .as_ref()
+                .and_then(|d| urlencoding::decode(d).ok())
+                .map(|d| d.to_string()),
+            org: self
+                .org
+                .as_ref()
+                .and_then(|o| urlencoding::decode(o).ok())
+                .map(|o| o.to_string()),
+        }
+    }
+}
+
+pub async fn list_handler(
+    State(state): State<Arc<Mutex<AppState>>>,
+    filters: Query<ReportFilters>,
+) -> impl IntoResponse {
+    // Remove URL encoding from strings in filters
+    let filters = filters.url_decode();
+
+    let reports: Vec<ReportHeader> = state
+        .lock()
+        .await
+        .tlsrpt_reports
+        .iter()
+        .filter(|(_, rwu)| {
+            if let Some(queried_uid) = filters.uid {
+                rwu.uid == queried_uid
+            } else {
+                true
+            }
+        })
+        .filter(|(_, rwu)| {
+            if let Some(org) = &filters.org {
+                rwu.report.organization_name == *org
+            } else {
+                true
+            }
+        })
+        .filter(|(_, rwu)| {
+            if let Some(domain) = &filters.domain {
+                rwu.report.policies.iter().any(|policy_result| policy_result.policy.policy_domain == *domain)
+            } else {
+                true
+            }
+        })
+        .map(|(hash, rwu)| ReportHeader::from_report(hash, &rwu.report))
+        .filter(|rh| {
+            if let Some(flagged) = &filters.flagged {
+                rh.flagged == *flagged
+            } else {
+                true
+            }
+        })
+        .filter(|rh| {
+            if let Some(sts) = &filters.flagged_sts {
+                rh.flagged_sts == *sts
+            } else {
+                true
+            }
+        })
+        .filter(|rh| {
+            if let Some(tlsa) = &filters.flagged_tlsa {
+                rh.flagged_tlsa == *tlsa
+            } else {
+                true
+            }
+        })
+        .collect();
+    Json(reports)
+}
+
+pub async fn single_handler(
+    State(state): State<Arc<Mutex<AppState>>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let lock = state.lock().await;
+    if let Some(rwu) = lock.tlsrpt_reports.get(&id) {
+        let report_json = serde_json::to_string(rwu).expect("Failed to serialize JSON");
+        (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "application/json")],
+            report_json,
+        )
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            [(header::CONTENT_TYPE, "text/plain")],
+            format!("Cannot find report with ID {id}"),
+        )
+    }
+}
+
+pub async fn json_handler(
+    State(state): State<Arc<Mutex<AppState>>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let lock = state.lock().await;
+    if let Some(rwu) = lock.tlsrpt_reports.get(&id) {
+        let report_json = serde_json::to_string(&rwu.report).expect("Failed to serialize JSON");
+        (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "application/json")],
+            report_json,
+        )
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            [(header::CONTENT_TYPE, "text/plain")],
+            format!("Cannot find report with ID {id}"),
+        )
+    }
+}

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -286,7 +286,9 @@ fn extract_metadata(mail: &Fetch, max_size: usize) -> Result<Mail> {
         size,
         oversized: size > max_size,
         xml_files: 0,
-        parsing_errors: 0,
+        json_files: 0,
+        xml_parsing_errors: 0,
+        json_parsing_errors: 0,
     })
 }
 

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -21,8 +21,14 @@ pub struct Mail {
     // Set at later stage when extracting the XML files from the body
     pub xml_files: usize,
 
+    // Set at later stage when extracting the JSON files from the body
+    pub json_files: usize,
+
     // Set at later stage during parsing
-    pub parsing_errors: usize,
+    pub xml_parsing_errors: usize,
+
+    // Set at later stage during parsing
+    pub json_parsing_errors: usize,
 }
 
 /// Decoding of Q-encoded data as described in RFC2047

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -7,8 +7,36 @@ use std::io::{Cursor, Read};
 use tracing::{trace, warn};
 use zip::ZipArchive;
 
-/// Get zero or more XML files from a ZIP archive
-fn get_xml_from_zip(zip_bytes: &[u8]) -> Result<Vec<Vec<u8>>> {
+/// The type of a file that can contain report data
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileType {
+    Json,
+    Xml,
+}
+
+/// The contents of a file that can contain report data, along with its type
+pub struct FileDataWithType {
+    /// The type of the file
+    pub file_type: FileType,
+    /// The binary data of the file
+    pub data: Vec<u8>,
+}
+
+/// In-memory representation of an unparsed report file with mail UID and hash
+pub struct ReportFile {
+    /// The type of the file
+    pub file_type: FileType,
+    /// UID of the mail that contained this report file
+    pub mail_uid: u32,
+    /// Binary data of the report file
+    pub data: Vec<u8>,
+    /// Hash of the report data AND mail UID.
+    /// UID needs to be included to avoid the same report file from multiple mails being treated as the same file!
+    pub hash: String,
+}
+
+/// Get zero or more report files from a ZIP archive
+fn get_reports_from_zip(zip_bytes: &[u8]) -> Result<Vec<FileDataWithType>> {
     let cursor = Cursor::new(zip_bytes);
     let mut archive = ZipArchive::new(cursor).context("Failed to binary data as ZIP")?;
 
@@ -17,23 +45,37 @@ fn get_xml_from_zip(zip_bytes: &[u8]) -> Result<Vec<Vec<u8>>> {
         warn!("ZIP file is empty");
     }
 
-    let mut xml_files = Vec::new();
+    let mut files = Vec::new();
     for i in 0..file_count {
         let mut file = archive.by_index(i).context("Unable to get file from ZIP")?;
         let file_name = file.name();
 
-        if !file_name.ends_with(".xml") {
-            warn!("File {file_name} in ZIP is not an XML file, skipping...",);
-            continue;
+        match file_name {
+            name if name.ends_with(".json") => {
+                let mut json_file = Vec::new();
+                file.read_to_end(&mut json_file)
+                    .context("Failed to read JSON from ZIP")?;
+                files.push(FileDataWithType {
+                    file_type: FileType::Json,
+                    data: json_file,
+                });
+            }
+            name if name.ends_with(".xml") => {
+                let mut xml_file = Vec::new();
+                file.read_to_end(&mut xml_file)
+                    .context("Failed to read XML from ZIP")?;
+                files.push(FileDataWithType {
+                    file_type: FileType::Xml,
+                    data: xml_file,
+                });
+            }
+            _ => {
+                warn!("File {file_name} in ZIP is not a JSON or XML file, skipping...");
+            }
         }
-
-        let mut xml_file = Vec::new();
-        file.read_to_end(&mut xml_file)
-            .context("Failed to read XML from ZIP")?;
-        xml_files.push(xml_file);
     }
 
-    Ok(xml_files)
+    Ok(files)
 }
 
 /// Merge name value of content type header in case its split like described
@@ -70,20 +112,20 @@ fn merge_name_parts(value: &str) -> String {
     out_buffer
 }
 
-/// Get a single XML file from a GZ archive
-fn get_xml_from_gz(gz_bytes: &[u8]) -> Result<Vec<u8>> {
+/// Get a single report file from a GZ archive
+fn get_report_from_gz(gz_bytes: &[u8]) -> Result<Vec<u8>> {
     let mut gz = GzDecoder::new(gz_bytes);
-    let mut xml_file = Vec::new();
-    gz.read_to_end(&mut xml_file)
+    let mut report_file = Vec::new();
+    gz.read_to_end(&mut report_file)
         .context("Failed to read file from GZ archive")?;
-    Ok(xml_file)
+    Ok(report_file)
 }
 
-pub fn extract_xml_files(mail: &mut Mail) -> Result<Vec<XmlFile>> {
+pub fn extract_report_files(mail: &mut Mail) -> Result<Vec<ReportFile>> {
     // Consume mail body to avoid keeping the longer needed data in memory
     let body = mail.body.take().context("Missing mail body")?;
 
-    let mut xml_files = Vec::new();
+    let mut report_files = Vec::new();
     let parsed = mailparse::parse_mail(&body).context("Failed to parse mail body")?;
     let parts: Vec<&ParsedMail> = parsed.parts().collect();
     let uid = mail.uid;
@@ -115,16 +157,17 @@ pub fn extract_xml_files(mail: &mut Mail) -> Result<Vec<XmlFile>> {
             let body = part
                 .get_body_raw()
                 .context("Failed to get raw body of attachment part")?;
-            let xml_files_zip =
-                get_xml_from_zip(&body).context("Failed to extract XML from ZIP attachment")?;
+            let report_files_zip =
+                get_reports_from_zip(&body).context("Failed to extract reports from ZIP attachment")?;
             trace!(
-                "Extracted {} XML files from ZIP in part {index} of mail with UID {uid}",
-                xml_files_zip.len()
+                "Extracted {} report files from ZIP in part {index} of mail with UID {uid}",
+                report_files_zip.len()
             );
-            for xml in xml_files_zip {
-                let hash = create_hash(&xml, Some(mail.uid));
-                xml_files.push(XmlFile {
-                    data: xml,
+            for report in report_files_zip {
+                let hash = create_hash(&report.data, Some(mail.uid));
+                report_files.push(ReportFile {
+                    file_type: report.file_type,
+                    data: report.data,
                     mail_uid: mail.uid,
                     hash,
                 });
@@ -132,13 +175,14 @@ pub fn extract_xml_files(mail: &mut Mail) -> Result<Vec<XmlFile>> {
         } else if content_type.contains("application/gzip")
             || content_type.contains("application/octet-stream") && content_type.contains(".xml.gz")
         {
-            trace!("Detected GZ attachment for mail with UID {uid} in part {index}");
+            trace!("Detected gzipped XML attachment for mail with UID {uid} in part {index}");
             let body = part
                 .get_body_raw()
                 .context("Failed to get raw body of attachment part")?;
-            let xml = get_xml_from_gz(&body).context("Failed to extract XML from GZ attachment")?;
+            let xml = get_report_from_gz(&body).context("Failed to extract XML from GZ attachment")?;
             let hash = create_hash(&xml, Some(mail.uid));
-            xml_files.push(XmlFile {
+            report_files.push(ReportFile {
+                file_type: FileType::Xml,
                 data: xml,
                 mail_uid: mail.uid,
                 hash,
@@ -151,26 +195,43 @@ pub fn extract_xml_files(mail: &mut Mail) -> Result<Vec<XmlFile>> {
                 .get_body_raw()
                 .context("Failed to get raw body of attachment part")?;
             let hash = create_hash(&xml, Some(mail.uid));
-            xml_files.push(XmlFile {
+            report_files.push(ReportFile {
+                file_type: FileType::Xml,
                 data: xml,
+                mail_uid: mail.uid,
+                hash,
+            });
+        } else if content_type.contains("application/tlsrpt+gzip")
+        {
+            trace!("Detected gzipped JSON attachment for mail with UID {uid} in part {index}");
+            let body = part
+                .get_body_raw()
+                .context("Failed to get raw body of attachment part")?;
+            let json = get_report_from_gz(&body).context("Failed to extract JSON from GZ attachment")?;
+            let hash = create_hash(&json, Some(mail.uid));
+            report_files.push(ReportFile {
+                file_type: FileType::Json,
+                data: json,
+                mail_uid: mail.uid,
+                hash,
+            });
+        } else if content_type.contains("application/tlsrpt+json")
+        {
+            trace!("Detected uncompressed JSON attachment for mail with UID {uid} in part {index}");
+            let json = part
+                .get_body_raw()
+                .context("Failed to get raw body of attachment part")?;
+            let hash = create_hash(&json, Some(mail.uid));
+            report_files.push(ReportFile {
+                file_type: FileType::Json,
+                data: json,
                 mail_uid: mail.uid,
                 hash,
             });
         }
     }
 
-    Ok(xml_files)
-}
-
-/// In-memory representation of an unparsed XML file with mail UID and hash
-pub struct XmlFile {
-    /// UID of the mail that contained this XML file
-    pub mail_uid: u32,
-    /// Binary data of the XML file
-    pub data: Vec<u8>,
-    /// Hash of the XML data AND mail UID.
-    /// UID needs to be included to avoid the same XML file from multiple mails being treated as the same file!
-    pub hash: String,
+    Ok(report_files)
 }
 
 #[cfg(test)]

--- a/ui/components/app.js
+++ b/ui/components/app.js
@@ -77,9 +77,14 @@ export class App extends LitElement {
         // Parse routes and route parameters
         if (hash == "#/dmarc-reports") {
             this.component = "dmarc-reports";
+        } else if (hash == "#/tlsrpt-reports") {
+            this.component = "tlsrpt-reports";
         } else if (hash.startsWith("#/dmarc-reports/")) {
             this.component = "dmarc-report";
             this.reportHash = hash.substring(16);
+        } else if (hash.startsWith("#/tlsrpt-reports/")) {
+            this.component = "tlsrpt-report";
+            this.reportHash = hash.substring(17);
         } else if (hash == "#/mails") {
             this.component = "mails";
         } else if (hash.startsWith("#/mails/")) {
@@ -96,8 +101,12 @@ export class App extends LitElement {
         let component;
         if (this.component == "dmarc-reports") {
             component = html`<drv-dmarc-reports .params="${this.params}"></drv-dmarc-reports>`;
+        } else if (this.component == "tlsrpt-reports") {
+            component = html`<drv-tlsrpt-reports .params="${this.params}"></drv-tlsrpt-reports>`;
         } else if (this.component == "dmarc-report") {
             component = html`<drv-dmarc-report hash="${this.reportHash}"></drv-dmarc-report>`;
+        } else if (this.component == "tlsrpt-report") {
+            component = html`<drv-tlsrpt-report hash="${this.reportHash}"></drv-tlsrpt-report>`;
         } else if (this.component == "mails") {
             component = html`<drv-mails .params="${this.params}"></drv-mails>`;
         } else if (this.component == "mail") {
@@ -112,8 +121,9 @@ export class App extends LitElement {
             <nav>
                 <a class="${this.component === "dashboard" ? "active" : ""}" href="#/dashboard">Dashboard</a>
                 <a class="${this.component === "mails" || this.component === "mail" ? "active" : ""}" href="#/mails">Mails</a>
-                <a class="${this.component === "dmarc-reports" || this.component === "dmarc-report" ? "active" : ""}" href="#/dmarc-reports">DMARC Reports</a>
-                <a class="${this.component === "about" ? "active" : ""} right" href="#/about">About</a>
+                <a class="${this.component === "dmarc-reports" || this.component === "dmarc-report" ? "active" : ""}" href="#/dmarc-reports">DMARC<span class="xs-hidden">&nbsp;Reports</span></a>
+                <a class="${this.component === "tlsrpt-reports" || this.component === "tlsrpt-report" ? "active" : ""}" href="#/tlsrpt-reports">TLS-RPT<span class="xs-hidden">&nbsp;Reports</span></a>
+                <a class="xs-hidden ${this.component === "about" ? "active" : ""} right" href="#/about">About</a>
             </nav>
             <main>${component}</main>
         `;

--- a/ui/components/dashboard.js
+++ b/ui/components/dashboard.js
@@ -35,9 +35,13 @@ export class Dashboard extends LitElement {
         params: { type: Object },
         mails: { type: Number },
         xmlFiles: { type: Number },
+        jsonFiles: { type: Number },
         dmarcReports: { type: Number },
+        tlsrptReports: { type: Number },
         lastUpdate: { type: Number },
-        domains: { type: Array },
+        dmarcDomains: { type: Array },
+        tlsrptDomains: { type: Array },
+        classesToHide: { type: Array },
     };
 
     constructor() {
@@ -46,9 +50,13 @@ export class Dashboard extends LitElement {
         this.params = {};
         this.mails = 0;
         this.xmlFiles = 0;
+        this.jsonFiles = 0;
         this.dmarcReports = 0;
+        this.tlsrptReports = 0;
         this.lastUpdate = 0;
-        this.domains = [];
+        this.dmarcDomains = [];
+        this.tlsrptDomains = [];
+        this.filterDomains = [];
 
         this.getDomains();
     }
@@ -56,8 +64,14 @@ export class Dashboard extends LitElement {
     async getDomains() {
         const response = await fetch("summary");
         const summary = await response.json();
-        this.domains = Object.keys(summary.dmarc_domains);
-        this.domains.sort();
+        this.dmarcDomains = Object.keys(summary.dmarc.domains);
+        this.dmarcDomains.sort();
+        this.tlsrptDomains = Object.keys(summary.tlsrpt.domains);
+        this.tlsrptDomains.sort();
+        this.filterDomains = [...new Set([
+            ...this.dmarcDomains,
+            ...this.tlsrptDomains
+        ])].sort();
     }
 
     updated(changedProperties) {
@@ -114,6 +128,7 @@ export class Dashboard extends LitElement {
         const summary = await response.json();
 
         const resultColorMap = {
+            // DMARC result colors
             "none": "rgb(108, 117, 125)",
             "fail": "rgb(220, 53, 69)",
             "pass": "rgb(25, 135, 84)",
@@ -122,9 +137,13 @@ export class Dashboard extends LitElement {
             "neutral": "rgb(13, 202, 240)",
             "temperror": "rgb(253, 126, 20)",
             "permerror": "rgb(132, 32, 41)",
+            // TLS-RPT result colors
+            "failure": "rgb(220, 53, 69)",
+            "successful": "rgb(25, 135, 84)",
         };
 
         const orgColorMap = {
+            // DMARC organization colors
             "google.com": "#ea4335",
             "Yahoo": "#6001d2",
             "WEB.DE": "#ffd800",
@@ -134,34 +153,84 @@ export class Dashboard extends LitElement {
             "Enterprise Outlook": "#0078d4",
             "Fastmail Pty Ltd": "#0067b9",
             "AMAZON-SES": "#ff9900",
+            // TLS-RPT organization colors
+            "Microsoft Corporation": "#0078d4",
+            "Google Inc.": "#ea4335",
         };
 
         this.mails = summary.mails;
-        this.xmlFiles = summary.xml_files;
-        this.dmarcReports = summary.dmarc_reports;
+        this.xmlFiles = summary.dmarc.files;
+        this.jsonFiles = summary.tlsrpt.files;
+        this.dmarcReports = summary.dmarc.reports;
+        this.tlsrptReports = summary.tlsrpt.reports;
         this.lastUpdate = summary.last_update;
 
-        if (this.orgs_chart) this.orgs_chart.destroy();
-        this.orgs_chart = await this.createPieChart("orgs_chart", this.sortedMap(summary.dmarc_orgs), orgColorMap, function (label) {
+        this.classesToHide = [];
+        if (this.dmarcReports === 0) this.classesToHide.push("dmarc");
+        if (this.tlsrptReports === 0) this.classesToHide.push("tlsrpt");
+        if (this.dmarcReports > 0) this.classesToHide.push("no_dmarc_reports");
+        if (this.tlsrptReports > 0) this.classesToHide.push("no_tlsrpt_reports");
+        if (Object.values(summary.dmarc.orgs).every((v) => v === 0)) this.classesToHide.push("dmarc_orgs");
+        if (Object.values(summary.dmarc.domains).every((v) => v === 0)) this.classesToHide.push("dmarc_domains");
+        if (Object.values(summary.dmarc.spf_policy_results).every((v) => v === 0)) this.classesToHide.push("spf_policy");
+        if (Object.values(summary.dmarc.dkim_policy_results).every((v) => v === 0)) this.classesToHide.push("dkim_policy");
+        if (Object.values(summary.dmarc.spf_auth_results).every((v) => v === 0)) this.classesToHide.push("spf_auth");
+        if (Object.values(summary.dmarc.dkim_auth_results).every((v) => v === 0)) this.classesToHide.push("dkim_auth");
+        if (Object.values(summary.tlsrpt.orgs).every((v) => v === 0)) this.classesToHide.push("tlsrpt_orgs");
+        if (Object.values(summary.tlsrpt.domains).every((v) => v === 0)) this.classesToHide.push("tlsrpt_domains");
+        if (Object.values(summary.tlsrpt.policy_types).every((v) => v === 0)) this.classesToHide.push("tlsrpt_policy_types");
+        if (Object.values(summary.tlsrpt.sts_policy_results).every((v) => v === 0)) this.classesToHide.push("sts_policy_results");
+        if (Object.values(summary.tlsrpt.sts_failure_types).every((v) => v === 0)) this.classesToHide.push("sts_failure_types");
+        if (Object.values(summary.tlsrpt.tlsa_policy_results).every((v) => v === 0)) this.classesToHide.push("tlsa_policy_results");
+        if (Object.values(summary.tlsrpt.tlsa_failure_types).every((v) => v === 0)) this.classesToHide.push("tlsa_failure_types");
+        
+        if (this.dmarc_orgs_chart) this.dmarc_orgs_chart.destroy();
+        this.dmarc_orgs_chart = await this.createPieChart("dmarc_orgs_chart", this.sortedMap(summary.dmarc.orgs), orgColorMap, function (label) {
             window.location.hash = "#/dmarc-reports?org=" + encodeURIComponent(label);
         });
 
-        if (this.domains_chart) this.domains_chart.destroy();
-        this.domains_chart = await this.createPieChart("domains_chart", this.sortedMap(summary.dmarc_domains), null, function (label) {
+        if (this.dmarc_domains_chart) this.dmarc_domains_chart.destroy();
+        this.dmarc_domains_chart = await this.createPieChart("dmarc_domains_chart", this.sortedMap(summary.dmarc.domains), null, function (label) {
             window.location.hash = "#/dmarc-reports?domain=" + encodeURIComponent(label);
         });
 
         if (this.spf_policy_chart) this.spf_policy_chart.destroy();
-        this.spf_policy_chart = await this.createPieChart("spf_policy_chart", this.sortedMap(summary.spf_policy_results), resultColorMap);
+        this.spf_policy_chart = await this.createPieChart("spf_policy_chart", this.sortedMap(summary.dmarc.spf_policy_results), resultColorMap);
 
         if (this.dkim_policy_chart) this.dkim_policy_chart.destroy();
-        this.dkim_policy_chart = await this.createPieChart("dkim_policy_chart", this.sortedMap(summary.dkim_policy_results), resultColorMap);
+        this.dkim_policy_chart = await this.createPieChart("dkim_policy_chart", this.sortedMap(summary.dmarc.dkim_policy_results), resultColorMap);
 
         if (this.spf_auth_chart) this.spf_auth_chart.destroy();
-        this.spf_auth_chart = await this.createPieChart("spf_auth_chart", this.sortedMap(summary.spf_auth_results), resultColorMap);
+        this.spf_auth_chart = await this.createPieChart("spf_auth_chart", this.sortedMap(summary.dmarc.spf_auth_results), resultColorMap);
 
         if (this.dkim_auth_chart) this.dkim_auth_chart.destroy();
-        this.dkim_auth_chart = await this.createPieChart("dkim_auth_chart", this.sortedMap(summary.dkim_auth_results), resultColorMap);
+        this.dkim_auth_chart = await this.createPieChart("dkim_auth_chart", this.sortedMap(summary.dmarc.dkim_auth_results), resultColorMap);
+
+
+        if (this.tlsrpt_orgs_chart) this.tlsrpt_orgs_chart.destroy();
+        this.tlsrpt_orgs_chart = await this.createPieChart("tlsrpt_orgs_chart", this.sortedMap(summary.tlsrpt.orgs), orgColorMap, function (label) {
+            window.location.hash = "#/tlsrpt-reports?org=" + encodeURIComponent(label);
+        });
+
+        if (this.tlsrpt_domains_chart) this.tlsrpt_domains_chart.destroy();
+        this.tlsrpt_domains_chart = await this.createPieChart("tlsrpt_domains_chart", this.sortedMap(summary.tlsrpt.domains), null, function (label) {
+            window.location.hash = "#/tlsrpt-reports?domain=" + encodeURIComponent(label);
+        });
+
+        if (this.tlsrpt_policy_types) this.tlsrpt_policy_types.destroy();
+        this.tlsrpt_policy_types = await this.createPieChart("tlsrpt_policy_types_chart", this.sortedMap(summary.tlsrpt.policy_types), null);
+
+        if (this.sts_policy_results) this.sts_policy_results.destroy();
+        this.sts_policy_results = await this.createPieChart("sts_policy_results_chart", this.sortedMap(summary.tlsrpt.sts_policy_results), resultColorMap);
+
+        if (this.sts_failure_types) this.sts_failure_types.destroy();
+        this.sts_failure_types = await this.createPieChart("sts_failure_types_chart", this.sortedMap(summary.tlsrpt.sts_failure_types), resultColorMap);
+
+        if (this.tlsa_policy_results) this.tlsa_policy_results.destroy();
+        this.tlsa_policy_results = await this.createPieChart("tlsa_policy_results_chart", this.sortedMap(summary.tlsrpt.tlsa_policy_results), resultColorMap);
+
+        if (this.tlsa_failure_types) this.tlsa_failure_types.destroy();
+        this.tlsa_failure_types = await this.createPieChart("tlsa_failure_types_chart", this.sortedMap(summary.tlsrpt.tlsa_failure_types), resultColorMap);
     }
 
     sortedMap(map) {
@@ -239,12 +308,20 @@ export class Dashboard extends LitElement {
 
     render() {
         return html`
+            <style>
+                ${(this.classesToHide ?? []).map(c => `.${c}`).join(",\n")} {
+                    display: none;
+                }
+            </style>
+
             <h1>Dashboard</h1>
 
             <div class="module stats">
                 <span>Mails: <b>${this.mails}</b></span>
-                <span>XML Files: <b>${this.xmlFiles}</b></span>
-                <span>DMARC Reports: <b>${this.dmarcReports}</b></span>
+                <span class="dmarc">XML Files: <b>${this.xmlFiles}</b></span>
+                <span class="dmarc">DMARC Reports: <b>${this.dmarcReports}</b></span>
+                <span class="tlsrpt">JSON Files: <b>${this.jsonFiles}</b></span>
+                <span class="tlsrpt">TLS-RPT Reports: <b>${this.tlsrptReports}</b></span>
                 <span>Last Update: <b>${new Date(this.lastUpdate * 1000).toLocaleString()}</b></span>
             </div>
 
@@ -265,7 +342,7 @@ export class Dashboard extends LitElement {
                     Domain:
                     <select @change="${this.onDomainChange}">
                         <option value="all">All</option>
-                        ${this.domains.map((domain) =>
+                        ${this.filterDomains.map((domain) =>
                         html`<option
                                 ?selected=${this.params.domain === encodeURIComponent(domain)}
                                 value="${encodeURIComponent(domain)}">${domain}</option>`
@@ -274,35 +351,78 @@ export class Dashboard extends LitElement {
                 </span>
             </div>
 
-            <div class="grid">
-                <div class="module">
+            <h2>DMARC Summary</h2>
+            <p class="no_dmarc_reports">No DMARC reports found.</p>
+
+            <div class="grid dmarc">
+                <div class="module dmarc dmarc_orgs">
                     <h2>DMARC Organizations</h2>
-                    <canvas class="orgs_chart"></canvas>
+                    <canvas class="dmarc_orgs_chart"></canvas>
                 </div>
 
-                <div class="module">
+                <div class="module dmarc dmarc_domains">
                     <h2>DMARC Domains</h2>
-                    <canvas class="domains_chart"></canvas>
+                    <canvas class="dmarc_domains_chart"></canvas>
                 </div>
 
-                <div class="module">
+                <div class="module dmarc spf_policy">
                     <h2>SPF Policy Results</h2>
                     <canvas class="spf_policy_chart"></canvas>
                 </div>
 
-                <div class="module">
+                <div class="module dmarc dkim_policy">
                     <h2>DKIM Policy Results</h2>
                     <canvas class="dkim_policy_chart"></canvas>
                 </div>
 
-                <div class="module">
+                <div class="module dmarc spf_auth">
                     <h2>SPF Auth Results</h2>
                     <canvas class="spf_auth_chart"></canvas>
                 </div>
 
-                <div class="module">
+                <div class="module dmarc dkim_auth">
                     <h2>DKIM Auth Results</h2>
                     <canvas class="dkim_auth_chart"></canvas>
+                </div>
+            </div>
+
+            <h2>TLS-RPT Summary</h2>
+            <p class="no_tlsrpt_reports">No TLS-RPT reports found.</p>
+
+            <div class="grid tlsrpt">
+                <div class="module tlsrpt tlsrpt_orgs">
+                    <h2>TLS-RPT Organizations</h2>
+                    <canvas class="tlsrpt_orgs_chart"></canvas>
+                </div>
+
+                <div class="module tlsrpt tlsrpt_domains">
+                    <h2>TLS-RPT Domains</h2>
+                    <canvas class="tlsrpt_domains_chart"></canvas>
+                </div>
+
+                <div class="module tlsrpt tlsrpt_policy_types">
+                    <h2>TLS-RPT Policy Types</h2>
+                    <canvas class="tlsrpt_policy_types_chart"></canvas>
+                </div>
+
+                <div class="module tlsrpt sts_policy_results">
+                    <h2>MTA-STS Policy Results</h2>
+                    <canvas class="sts_policy_results_chart"></canvas>
+                </div>
+
+                <div class="module tlsrpt sts_failure_types">
+                    <h2>MTA-STS Failure Types</h2>
+                    <canvas class="sts_failure_types_chart"></canvas>
+                </div>
+
+                <div class="module tlsrpt tlsa_policy_results">
+                    <h2>DANE TLSA Policy Results</h2>
+                    <canvas class="tlsa_policy_results_chart"></canvas>
+                </div>
+
+                <div class="module tlsrpt tlsa_failure_types">
+                    <h2>DANE TLSA Failure Types</h2>
+                    <canvas class="tlsa_failure_types_chart"></canvas>
                 </div>
             </div>
         `;

--- a/ui/components/dmarc-report-table.js
+++ b/ui/components/dmarc-report-table.js
@@ -1,7 +1,7 @@
-import { LitElement, html, css } from "lit";
+import { LitElement, html } from "lit";
 import { globalStyle } from "./style.js";
 
-export class ReportTable extends LitElement {
+export class DmarcReportTable extends LitElement {
     static styles = [globalStyle];
 
     static properties = {
@@ -65,4 +65,4 @@ export class ReportTable extends LitElement {
     }
 }
 
-customElements.define("drv-dmarc-report-table", ReportTable);
+customElements.define("drv-dmarc-report-table", DmarcReportTable);

--- a/ui/components/dmarc-report.js
+++ b/ui/components/dmarc-report.js
@@ -1,7 +1,7 @@
 import { LitElement, html, css } from "lit";
 import { globalStyle } from "./style.js";
 
-export class Report extends LitElement {
+export class DmarcReport extends LitElement {
     static styles = [globalStyle];
 
     static get properties() {
@@ -87,6 +87,9 @@ export class Report extends LitElement {
     }
 
     renderLocation(lat, lon) {
+        if (lat === undefined || lon === undefined) {
+            return html`<span class="faded">n/a</span>`;
+        }
         return html`<a target="_blank" title="Show on OpenStreeMap" href="https://www.openstreetmap.org/#map=8/${lat}/${lon}">${lat}, ${lon}</a>`;
     }
 
@@ -132,11 +135,11 @@ export class Report extends LitElement {
                     <th colspan="2">Report Header</td>
                 </tr>
                 <tr>
-                    <td class="name">Id</td>
+                    <td class="name">ID</td>
                     <td>${this.report.report_metadata.report_id}</td>
                 </tr>
                 <tr>
-                    <td class="name">Org</td>
+                    <td class="name">Organization</td>
                     <td>${this.report.report_metadata.org_name}</td>
                 </tr>
                 <tr>
@@ -168,7 +171,7 @@ export class Report extends LitElement {
                     <td>${this.renderOptional(this.report.version)}</td>
                 </tr>
                 <tr>
-                    <th class="name" colspan="2">Published Policy</th>
+                    <th colspan="2">Published Policy</th>
                 </tr>
                 <tr>
                     <td class="name">Domain</td>
@@ -210,7 +213,7 @@ export class Report extends LitElement {
                         <td>
                             ${record.row.source_ip}
                             <button @click="${() => this.lookupIp(record.row.source_ip)}" class="button sm help" title="Search DNS hostname for IP and geolocate it">DNS and Location</button>
-                            <a class="button sm help" title="Look up whois record for IP and show in new tab" target="blank" href="/ips/${record.row.source_ip}/whois">Whois</a>
+                            <a class="button sm help" title="Look up WHOIS record for IP and show in new tab" target="blank" href="/ips/${record.row.source_ip}/whois">WHOIS</a>
                         </td>
                     </tr>
                     <tbody class="sourceip" style="${this.ipDetails[record.row.source_ip] ? "": "display:none"}">
@@ -247,7 +250,7 @@ export class Report extends LitElement {
                             <td class="name">Source IP Location</td>
                             <td>${this.ip2location[record.row.source_ip] === undefined ?
                                     html`<span class="faded">loading</span>` :
-                                    this.renderLocation(this.ip2location[record.row.source_ip].lat, this.ip2location[record.row.source_ip].lon)
+                                    this.renderLocation(this.ip2location[record.row.source_ip]?.lat, this.ip2location[record.row.source_ip]?.lon)
                                 }
                             </td>
                         </tr>
@@ -335,4 +338,4 @@ export class Report extends LitElement {
     }
 }
 
-customElements.define("drv-dmarc-report", Report);
+customElements.define("drv-dmarc-report", DmarcReport);

--- a/ui/components/mail-table.js
+++ b/ui/components/mail-table.js
@@ -34,20 +34,23 @@ export class MailTable extends LitElement {
         }
     }
 
-    prepareXmlFileCount(mail) {
+    prepareReportType(mail) {
         if (mail.oversized) {
             return html`<span class="faded">n/a</span>`;
-        } else if (mail.xml_files < 1) {
-            return html`<span class="badge badge-negative">${mail.xml_files}</span>`;
+        } else if (mail.xml_files < 1 && mail.json_files < 1) {
+            return html`<span class="badge badge-negative">None</span>`;
         } else {
-            return html`<span class="faded">${mail.xml_files}</span>`;
+            const files = [];
+            if (mail.xml_files > 0) files.push("DMARC");
+            if (mail.json_files > 0) files.push("TLS-RPT");
+            return html`<span class="faded">${files.join(", ")}</span>`;
         }
     }
 
     prepareParsingError(mail) {
         if (mail.oversized) {
             return html`<span class="faded">n/a</span>`;
-        } else if (mail.parsing_errors > 0) {
+        } else if (mail.xml_parsing_errors > 0 || mail.json_parsing_errors > 0) {
             return html`<span class="badge badge-negative">Yes</span>`;
         } else {
             return html`<span class="faded">No</span>`;
@@ -62,8 +65,8 @@ export class MailTable extends LitElement {
                     <th class="sm-hidden">Sender</th>
                     <th class="md-hidden">Date</th>
                     <th class="xs-hidden help" title="Size of E-Mail in Bytes">Size</th>
-                    <th class="md-hidden help" title="Number of XML files in the Mail">XMLs</th>
-                    <th class="xs-hidden help" title="Did the Mail cause DMARC Parsing Errors?">Errors</th>
+                    <th class="md-hidden help" title="Type of reports in the Mail">Type</th>
+                    <th class="xs-hidden help" title="Did the Mail cause Parsing Errors?">Errors</th>
                 </tr>
                 ${this.mails.length !== 0 ? this.mails.map((mail) =>
                     html`<tr> 
@@ -71,11 +74,11 @@ export class MailTable extends LitElement {
                         <td class="sm-hidden"><a href="#/mails?sender=${encodeURIComponent(mail.sender)}">${mail.sender}</a></td>
                         <td class="md-hidden">${new Date(mail.date * 1000).toLocaleString()}</td>
                         <td class="xs-hidden">${this.prepareSize(mail)}</td>
-                        <td class="md-hidden">${this.prepareXmlFileCount(mail)}</td>
+                        <td class="md-hidden">${this.prepareReportType(mail)}</td>
                         <td class="xs-hidden">${this.prepareParsingError(mail)}</td>
                     </tr>`
                 ) : html`<tr>
-                        <td colspan="4">No mails found.</td>
+                        <td colspan="6">No mails found.</td>
                     </tr>`
                 }
             </table>

--- a/ui/components/mails.js
+++ b/ui/components/mails.js
@@ -30,8 +30,8 @@ export class Mails extends LitElement {
         if (this.params.sender) {
             queryParams.push("sender=" + encodeURIComponent(this.params.sender));
         }
-        if (this.params.count) {
-            queryParams.push("count=" + encodeURIComponent(this.params.count));
+        if (this.params.type) {
+            queryParams.push("type=" + encodeURIComponent(this.params.type));
         }
         if (this.params.errors === "true" || this.params.errors === "false") {
             queryParams.push("errors=" + this.params.errors);
@@ -53,7 +53,9 @@ export class Mails extends LitElement {
                 ${this.filtered ?
                     html`Filter active! <a class="ml button" href="#/mails">Show all Mails</a>` :
                     html`Filters: <a class="ml button" href="#/mails?oversized=true">Oversized Mails</a>
-                         <a class="button" href="#/mails?count=0&oversized=false">Without XML Files</a>
+                         <a class="button" href="#/mails?type=dmarc&oversized=false">With DMARC</a>
+                         <a class="button" href="#/mails?type=tlsrpt&oversized=false">With TLS-RPT</a>
+                         <a class="button" href="#/mails?type=empty&oversized=false">Without Files</a>
                          <a class="button" href="#/mails?errors=true">Parsing Errors</a>`
             }
             </div>

--- a/ui/components/tlsrpt-report-table.js
+++ b/ui/components/tlsrpt-report-table.js
@@ -1,0 +1,77 @@
+import { LitElement, html } from "lit";
+import { globalStyle } from "./style.js";
+
+export class TlsRptReportTable extends LitElement {
+    static styles = [globalStyle];
+
+    static properties = {
+        reports: { type: Array },
+    };
+
+    constructor() {
+        super();
+        this.reports = [];
+    }
+
+    prepareId(id) {
+        const limit = 25;
+        if (id.length <= limit) {
+            return id;
+        } else {
+            return id.substring(0, limit) + "...";
+        }
+    }
+
+    renderProblemBadges(sts, tlsa) {
+        const badges = [];
+        if (sts) {
+            badges.push(html`<span class="badge badge-negative">MTA-STS</span>`);
+        }
+        if (tlsa) {
+            badges.push(html` <span class="badge badge-negative">TLSA</span>`);
+        }
+        return badges;
+    }
+
+    renderDomains(domains) {
+        if (domains.length === 0) {
+            return html`<span class="faded">No domains</span>`;
+        }
+        return domains.reduce((acc, domain) => acc.concat(html`, `, html`
+            <a href="#/tlsrpt-reports?domain=${encodeURIComponent(domain)}">${domain}</a>
+        `), []).slice(1);
+    }
+
+    render() {
+        return html`
+            <table>
+                <tr>
+                    <th>ID</th>
+                    <th class="xs-hidden">Organization</th>
+                    <th class="sm-hidden">Domains</th>
+                    <th class="help" title="Reports with MTA-STS or TLSA problems are highlighted in red">Problems</th>
+                    <th class="sm-hidden">Policies</th>
+                    <th class="md-hidden">Begin</th>
+                    <th class="md-hidden">End</th>
+                </tr>
+                ${this.reports.length !== 0 ? this.reports.map((report) =>
+                    html`<tr>
+                            <td><a href="#/tlsrpt-reports/${report.hash}" title="${report.id}">${this.prepareId(report.id)}</a></td>
+                            <td class="xs-hidden"><a href="#/tlsrpt-reports?org=${encodeURIComponent(report.org)}">${report.org}</a></td>
+                            <td class="sm-hidden">${this.renderDomains(report.domains)}</td>
+                            <td>${this.renderProblemBadges(report.flagged_sts, report.flagged_tlsa)}</td>
+                            <td class="sm-hidden">${report.records}</td>
+                            <td class="md-hidden">${new Date(report.date_begin).toLocaleString()}</td>
+                            <td class="md-hidden">${new Date(report.date_end).toLocaleString()}</td>
+                        </tr>`
+
+                ) : html`<tr>
+                            <td colspan="7">No reports found.</td>
+                        </tr>`
+                }
+            </table>
+        `;
+    }
+}
+
+customElements.define("drv-tlsrpt-report-table", TlsRptReportTable);

--- a/ui/components/tlsrpt-report.js
+++ b/ui/components/tlsrpt-report.js
@@ -1,0 +1,372 @@
+import { LitElement, html, css } from "lit";
+import { globalStyle } from "./style.js";
+
+export class TlsRptReport extends LitElement {
+    static styles = [globalStyle];
+
+    static get properties() {
+        return {
+            hash: { type: String },
+            uid: { type: String, attribute: false },
+        };
+    }
+
+    constructor() {
+        super();
+        this.hash = null;
+        this.uid = null;
+        this.report = null;
+        this.ip2dns = {};
+        this.ip2location = {};
+        this.ipDetails = {};
+    }
+
+    async updated(changedProperties) {
+        if (changedProperties.has("hash") && changedProperties.hash !== this.hash && this.hash) {
+            const response = await fetch("tlsrpt-reports/" + this.hash);
+            const rwu = await response.json();
+            this.report = rwu.report;
+            this.uid = rwu.uid;
+        }
+    }
+
+    async lookupIp(ip) {
+        if (this.ipDetails[ip]) {
+            this.ipDetails[ip] = false;
+        } else {
+            this.ipDetails[ip] = true;
+            this.getDnsForIp(ip);
+            this.getLocationForIp(ip);
+        }
+        this.requestUpdate();
+    }
+
+    async getDnsForIp(ip) {
+        const response = await fetch("ips/" + ip + "/dns");
+        if (response.status === 200) {
+            const result = await response.text();
+            this.ip2dns[ip] = result;
+        } else {
+            this.ip2dns[ip] = null;
+        }
+        this.requestUpdate();
+    }
+
+    async getLocationForIp(ip) {
+        const response = await fetch("ips/" + ip + "/location");
+        if (response.status === 200) {
+            const result = await response.json();
+            this.ip2location[ip] = result;
+        } else {
+            this.ip2location[ip] = null;
+        }
+        this.requestUpdate();
+    }
+
+    renderPolicyTypeBadge(result) {
+        switch (result) {
+            case "no-policy-found":
+                return html`<span class="faded">No Policy Found</span>`;
+            case "sts":
+                return html`<span class="badge">MTA-STS</span>`;
+            case "tlsa":
+                return html`<span class="badge">TLSA</span>`;
+        }
+        return html`<span class="badge">${result}</span>`;
+    }
+
+    renderFailureCountBadge(count) {
+        if (count === 0) {
+            return html`<span class="badge badge-positive">0</span>`;
+        } else {
+            return html`<span class="badge badge-negative">${count}</span>`;
+        }
+    }
+
+    renderFailureResultType(type) {
+        switch (type) {
+            case "starttls-not-supported":
+                return html`STARTTLS not supported`;
+            case "certificate-host-mismatch":
+                return html`Certificate host mismatch`;
+            case "certificate-expired":
+                return html`Certificate expired`;
+            case "certificate-not-trusted":
+                return html`Certificate not trusted`;
+            case "validation-failure":
+                return html`Validation failure`;
+            case "tlsa-invalid":
+                return html`TLSA invalid`;
+            case "dnssec-invalid":
+                return html`DNSSEC invalid`;
+            case "dane-required":
+                return html`DANE required`;
+            case "sts-policy-fetch-error":
+                return html`MTA-STS policy fetch error`;
+            case "sts-policy-invalid":
+                return html`MTA-STS policy invalid`;
+            case "sts-webpki-invalid":
+                return html`MTA-STS WebPKI invalid`;
+        }
+        return html`${type}`;
+    }
+
+    renderMultilineCell(array) {
+        return array.reduce((acc, line) => acc.concat(html`<br>`, html`${line}`), []).slice(1);
+    }
+
+    renderLocation(lat, lon) {
+        if (lat === undefined || lon === undefined) {
+            return html`<span class="faded">n/a</span>`;
+        }
+        return html`<a target="_blank" title="Show on OpenStreeMap" href="https://www.openstreetmap.org/#map=8/${lat}/${lon}">${lat}, ${lon}</a>`;
+    }
+
+    renderPropIfObjDefined(obj, prop) {
+        if (obj === undefined) {
+            return html`<span class="faded">loading...</span>`;
+        } else if (obj) {
+            return obj[prop]
+        } else {
+            return html`<span class="faded">n/a</span>`;
+        }
+    }
+
+    renderIfDefined(obj) {
+        if (obj === undefined) {
+            return html`<span class="faded">loading...</span>`;
+        } else if (obj) {
+            return obj;
+        } else {
+            return html`<span class="faded">n/a</span>`;
+        }
+    }
+
+    render() {
+        if (!this.report) {
+            return html`No report loaded`;
+        }
+
+        return html`
+            <h1>Report Details</h1>
+            <p>
+                <a class="button" href="#/mails/${this.uid}">Show Mail</a>
+                <a class="button" href="/tlsrpt-reports/${this.hash}/json" target="_blank">Open JSON</a>
+            </p>
+            <table>
+                <tr>
+                    <th colspan="2">Report Header</td>
+                </tr>
+                <tr>
+                    <td class="name">ID</td>
+                    <td>${this.report["report-id"]}</td>
+                </tr>
+                <tr>
+                    <td class="name">Organization</td>
+                    <td>${this.report["organization-name"]}</td>
+                </tr>
+                <tr>
+                    <td class="name">Evaluated Policies</td>
+                    <td>${this.report.policies.length}</td>
+                </tr>
+                <tr>
+                    <td class="name">Date Range Begin</td>
+                    <td>${new Date(this.report["date-range"]["start-datetime"]).toLocaleString()}</td>
+                </tr>
+                <tr>
+                    <td class="name">Date Range End</td>
+                    <td>${new Date(this.report["date-range"]["end-datetime"]).toLocaleString()}</td>
+                </tr>
+                <tr>
+                    <td class="name">Contact Info</td>
+                    <td>${this.report["contact-info"]}</td>
+                </tr>
+            </table>
+
+            ${this.report.policies.sort((a, b) => a.policy["policy-type"].localeCompare(b.policy["policy-type"])).map((policy) => html`
+                <h2>Policy</h2>
+                <table>
+                    <tbody>
+                        <tr>
+                            <th colspan="2">Published Policy</td>
+                        </tr>
+                        <tr>
+                            <td class="name">Policy Type</td>
+                            <td>${this.renderPolicyTypeBadge(policy.policy["policy-type"])}</td>
+                        </tr>
+                        ${"policy-string" in policy.policy ? html`
+                            <tr>
+                                <td class="name">Policy String</td>
+                                <td>${this.renderMultilineCell(policy.policy["policy-string"])}</td>
+                            </tr>
+                        ` : html``}
+                        <tr>
+                            <td class="name">Policy Domain</td>
+                            <td>${policy.policy["policy-domain"]}</td>
+                        </tr>
+                        ${"mx-host" in policy.policy ? html`
+                            <tr>
+                                <td class="name">MX Host</td>
+                                <td>${this.renderMultilineCell(policy.policy["mx-host"])}</td>
+                            </tr>
+                        ` : html``}
+
+                        <tr>
+                            <th colspan="2">Summary</td>
+                        </tr>
+                        <tr>
+                            <td class="name">Successful Count</td>
+                            <td>${policy.summary["total-successful-session-count"]}</td>
+                        </tr>
+                        <tr>
+                            <td class="name">Failure Count</td>
+                            <td>${this.renderFailureCountBadge(policy.summary["total-failure-session-count"])}</td>
+                        </tr>
+                    </tbody>
+
+                    ${"failure-details" in policy ? policy["failure-details"].map((failureDetails) => html`
+                        <tbody>
+                            <tr>
+                                <th colspan="2">Failure Details – ${this.renderFailureResultType(failureDetails["result-type"])}</td>
+                            </tr>
+                            <tr>
+                                <td class="name">Failure Result Type</td>
+                                <td>${this.renderFailureResultType(failureDetails["result-type"])}</td>
+                            </tr>
+                            <tr>
+                                <td class="name">Sending MTA IP</td>
+                                <td>
+                                    ${failureDetails["sending-mta-ip"]}
+                                    <button @click="${() => this.lookupIp(failureDetails["sending-mta-ip"])}" class="button sm help" title="Search DNS hostname for IP and geolocate it">DNS and Location</button>
+                                    <a class="button sm help" title="Look up WHOIS record for IP and show in new tab" target="blank" href="/ips/${failureDetails["sending-mta-ip"]}/whois">WHOIS</a>
+                                </td>
+                            </tr>
+                        </tbody>
+                        <tbody class="sourceip" style="${this.ipDetails[failureDetails["sending-mta-ip"]] ? "": "display:none"}">
+                            <tr>
+                                <td class="name">Sending MTA IP DNS</td>
+                                <td>${this.renderIfDefined(this.ip2dns[failureDetails["sending-mta-ip"]])}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="name">Sending MTA IP Country</td>
+                                <td>${this.renderPropIfObjDefined(this.ip2location[failureDetails["sending-mta-ip"]], "country")}</td>
+                            </tr>
+                            <tr>
+                                <td class="name">Sending MTA IP City</td>
+                                <td>${this.renderPropIfObjDefined(this.ip2location[failureDetails["sending-mta-ip"]], "city")}</td>
+                            </tr>
+                            <tr>
+                                <td class="name">Sending MTA IP ISP</td>
+                                <td>${this.renderPropIfObjDefined(this.ip2location[failureDetails["sending-mta-ip"]], "isp")}</td>
+                            </tr>
+                            <tr>
+                                <td class="name">Sending MTA IP AS</td>
+                                <td>${this.renderPropIfObjDefined(this.ip2location[failureDetails["sending-mta-ip"]], "as")}</td>
+                            </tr>
+                            <tr>
+                                <td class="name help" title="Known Proxy, VPN or Tor exit address?">Sending MTA IP Proxy</td>
+                                <td>${this.renderPropIfObjDefined(this.ip2location[failureDetails["sending-mta-ip"]], "proxy")}</td>
+                            </tr>
+                            <tr>
+                                <td class="name help" title="Known data center, hosting or colocated">Sending MTA IP Data Center</td>
+                                <td>${this.renderPropIfObjDefined(this.ip2location[failureDetails["sending-mta-ip"]], "hosting")}</td>
+                            </tr>
+                            <tr>
+                                <td class="name">Sending MTA IP Location</td>
+                                <td>${this.ip2location[failureDetails["sending-mta-ip"]] === undefined ?
+                                        html`<span class="faded">loading</span>` :
+                                        this.renderLocation(this.ip2location[failureDetails["sending-mta-ip"]]?.lat, this.ip2location[failureDetails["sending-mta-ip"]]?.lon)
+                                    }
+                                </td>
+                            </tr>
+                        </tbody>
+                        <tbody>
+                            <tr>
+                                <td class="name">Receiving MX Hostname</td>
+                                <td>${failureDetails["receiving-mx-hostname"]}</td>
+                            </tr>
+                            ${"receiving-mx-helo" in failureDetails ? html`
+                                <tr>
+                                    <td class="name">Receiving MTA HELO</td>
+                                    <td>${failureDetails["receiving-mx-helo"]}</td>
+                                </tr>
+                            ` : html``}
+                        </tbody>
+                        ${"receiving-ip" in failureDetails ? html`
+                            <tbody>
+                                <tr>
+                                    <td class="name">Receiving IP</td>
+                                    <td>
+                                        ${failureDetails["receiving-ip"]}
+                                        <button @click="${() => this.lookupIp(failureDetails["receiving-ip"])}" class="button sm help" title="Search DNS hostname for IP and geolocate it">DNS and Location</button>
+                                        <a class="button sm help" title="Look up WHOIS record for IP and show in new tab" target="blank" href="/ips/${failureDetails["receiving-ip"]}/whois">WHOIS</a>
+                                    </td>
+                                </tr>
+                            </tbody>
+                            <tbody class="sourceip" style="${this.ipDetails[failureDetails["receiving-ip"]] ? "": "display:none"}">
+                                <tr>
+                                    <td class="name">Receiving IP DNS</td>
+                                    <td>${this.renderIfDefined(this.ip2dns[failureDetails["receiving-ip"]])}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="name">Receiving IP Country</td>
+                                    <td>${this.renderPropIfObjDefined(this.ip2location[failureDetails["receiving-ip"]], "country")}</td>
+                                </tr>
+                                <tr>
+                                    <td class="name">Receiving IP City</td>
+                                    <td>${this.renderPropIfObjDefined(this.ip2location[failureDetails["receiving-ip"]], "city")}</td>
+                                </tr>
+                                <tr>
+                                    <td class="name">Receiving IP ISP</td>
+                                    <td>${this.renderPropIfObjDefined(this.ip2location[failureDetails["receiving-ip"]], "isp")}</td>
+                                </tr>
+                                <tr>
+                                    <td class="name">Receiving IP AS</td>
+                                    <td>${this.renderPropIfObjDefined(this.ip2location[failureDetails["receiving-ip"]], "as")}</td>
+                                </tr>
+                                <tr>
+                                    <td class="name help" title="Known Proxy, VPN or Tor exit address?">Receiving IP Proxy</td>
+                                    <td>${this.renderPropIfObjDefined(this.ip2location[failureDetails["receiving-ip"]], "proxy")}</td>
+                                </tr>
+                                <tr>
+                                    <td class="name help" title="Known data center, hosting or colocated">Receiving IP Data Center</td>
+                                    <td>${this.renderPropIfObjDefined(this.ip2location[failureDetails["receiving-ip"]], "hosting")}</td>
+                                </tr>
+                                <tr>
+                                    <td class="name">Receiving IP Location</td>
+                                    <td>${this.ip2location[failureDetails["receiving-ip"]] === undefined ?
+                                            html`<span class="faded">loading</span>` :
+                                            this.renderLocation(this.ip2location[failureDetails["receiving-ip"]]?.lat, this.ip2location[failureDetails["receiving-ip"]]?.lon)
+                                        }
+                                    </td>
+                                </tr>
+                            </tbody>
+                        ` : html``}
+                        <tbody>
+                            <tr>
+                                <td class="name">Failed Session Count</td>
+                                <td>${failureDetails["failed-session-count"]}</td>
+                            </tr>
+                            ${"additional-information" in failureDetails ? html`
+                                <tr>
+                                    <td class="name">Additional Information</td>
+                                    <td>${failureDetails["additional-information"]}</td>
+                                </tr>
+                            ` : html``}
+                            ${"failure-reason-code" in failureDetails ? html`
+                                <tr>
+                                    <td class="name">Failure Reason Code</td>
+                                    <td>${failureDetails["failure-reason-code"]}</td>
+                                </tr>
+                            ` : html``}
+                        </tbody>
+                    `) : html``}
+                </table>
+            `)}
+        `;
+    }
+}
+
+customElements.define("drv-tlsrpt-report", TlsRptReport);

--- a/ui/components/tlsrpt-reports.js
+++ b/ui/components/tlsrpt-reports.js
@@ -1,7 +1,7 @@
 import { LitElement, html } from "lit";
 import { globalStyle } from "./style.js";
 
-export class DmarcReports extends LitElement {
+export class TlsRptReports extends LitElement {
     static styles = [globalStyle];
 
     static properties = {
@@ -27,11 +27,11 @@ export class DmarcReports extends LitElement {
         if (this.params.flagged === "true" || this.params.flagged === "false") {
             urlParams.push("flagged=" + this.params.flagged);
         }
-        if (this.params.flagged_dkim === "true" || this.params.flagged_dkim === "false") {
-            urlParams.push("flagged_dkim=" + this.params.flagged_dkim);
+        if (this.params.flagged_sts === "true" || this.params.flagged_sts === "false") {
+            urlParams.push("flagged_sts=" + this.params.flagged_sts);
         }
-        if (this.params.flagged_spf === "true" || this.params.flagged_spf === "false") {
-            urlParams.push("flagged_spf=" + this.params.flagged_spf);
+        if (this.params.flagged_tlsa === "true" || this.params.flagged_tlsa === "false") {
+            urlParams.push("flagged_tlsa=" + this.params.flagged_tlsa);
         }
         if (this.params.domain) {
             urlParams.push("domain=" + encodeURIComponent(this.params.domain));
@@ -39,32 +39,32 @@ export class DmarcReports extends LitElement {
         if (this.params.org) {
             urlParams.push("org=" + encodeURIComponent(this.params.org));
         }
-        let url = "dmarc-reports";
+        let url = "tlsrpt-reports";
         if (urlParams.length > 0) {
             url += "?" + urlParams.join("&");
         }
         const response = await fetch(url);
         this.reports = await response.json();
-        this.reports.sort((a, b) => b.date_begin - a.date_begin);
+        this.reports.sort((a, b) => new Date(b.date_begin) - new Date(a.date_begin));
         this.filtered = this.filtered = urlParams.length > 0;
     }
 
     render() {
         return html`
-            <h1>DMARC Reports</h1>
+            <h1>TLS-RPT Reports</h1>
             <div>
                 ${this.filtered ?
-                    html`Filter active! <a class="ml button" href="#/dmarc-reports">Show all Reports</a>` :
+                    html`Filter active! <a class="ml button" href="#/tlsrpt-reports">Show all Reports</a>` :
                     html`Filters:
-                        <a class="ml button mr-5" href="#/dmarc-reports?flagged=true">Reports with Problems</a>
-                        <a class="button mr-5" href="#/dmarc-reports?flagged_dkim=true">Reports with DKIM Problems</a>
-                        <a class="button mr-5" href="#/dmarc-reports?flagged_spf=true">Reports with SPF Problems</a>
+                        <a class="ml button mr-5" href="#/tlsrpt-reports?flagged=true">Reports with Problems</a>
+                        <a class="button mr-5" href="#/tlsrpt-reports?flagged_sts=true">Reports with STS Problems</a>
+                        <a class="button mr-5" href="#/tlsrpt-reports?flagged_tlsa=true">Reports with TLSA Problems</a>
                     `
                 }
             </div>
-            <drv-dmarc-report-table .reports="${this.reports}"></drv-dmarc-report-table>
+            <drv-tlsrpt-report-table .reports="${this.reports}"></drv-tlsrpt-report-table>
         `;
     }
 }
 
-customElements.define("drv-dmarc-reports", DmarcReports);
+customElements.define("drv-tlsrpt-reports", TlsRptReports);

--- a/ui/index.html
+++ b/ui/index.html
@@ -16,6 +16,9 @@
         import "./components/dmarc-report-table.js";
         import "./components/dmarc-reports.js";
         import "./components/dmarc-report.js";
+        import "./components/tlsrpt-report-table.js";
+        import "./components/tlsrpt-reports.js";
+        import "./components/tlsrpt-report.js";
         import "./components/mail-table.js";
         import "./components/mails.js";
         import "./components/mail.js";


### PR DESCRIPTION
* Unpack and parse TLS-RPT reports from mails
* Add JSON parsing errors to mail errors handler
* Add TLS-RPT reports to summary handler
* Add TLS-RPT report handlers (list with filter, single, JSON)
* Add TLS-RPT list, report views
* Add JSON parsing errors, TLS-RPT reports to mail table, mail details views
* Change file count column to file type column in mail table
* Add TLS-RPT charts to dashboard
* Hide empty charts, section from dashboard
* Shorten menu bar entries on small screens
* Fix location rendering for invalid location