### PR TITLE
Flag reports with failed DMARC validation

### DIFF
--- a/ui/components/dmarc-report-table.js
+++ b/ui/components/dmarc-report-table.js
@@ -22,13 +22,16 @@ export class DmarcReportTable extends LitElement {
         }
     }
 
-    renderProblemBadges(dkim, spf) {
+    renderProblemBadges(dkim, spf, dmarc) {
         const badges = [];
         if (dkim) {
             badges.push(html`<span class="badge badge-negative mr-5">DKIM</span>`);
         }
         if (spf) {
             badges.push(html` <span class="badge badge-negative">SPF</span>`);
+        }
+        if (dmarc) {
+            badges.push(html` <span class="badge badge-negative">DMARC</span>`);
         }
         return badges;
     }
@@ -50,7 +53,7 @@ export class DmarcReportTable extends LitElement {
                             <td><a href="#/dmarc-reports/${report.hash}" title="${report.id}">${this.prepareId(report.id)}</a></td>
                             <td class="xs-hidden"><a href="#/dmarc-reports?org=${encodeURIComponent(report.org)}">${report.org}</a></td>
                             <td class="sm-hidden"><a href="#/dmarc-reports?domain=${encodeURIComponent(report.domain)}">${report.domain}</a></td>
-                            <td>${this.renderProblemBadges(report.flagged_dkim, report.flagged_spf)}</td>
+                            <td>${this.renderProblemBadges(report.flagged_dkim, report.flagged_spf, report.flagged_dmarc)}</td>
                             <td class="sm-hidden">${report.records}</td>
                             <td class="md-hidden">${new Date(report.date_begin * 1000).toLocaleString()}</td>
                             <td class="md-hidden">${new Date(report.date_end * 1000).toLocaleString()}</td>

--- a/ui/components/dmarc-reports.js
+++ b/ui/components/dmarc-reports.js
@@ -33,6 +33,9 @@ export class DmarcReports extends LitElement {
         if (this.params.flagged_spf === "true" || this.params.flagged_spf === "false") {
             urlParams.push("flagged_spf=" + this.params.flagged_spf);
         }
+        if (this.params.flagged_dmarc === "true" || this.params.flagged_dmarc === "false") {
+            urlParams.push("flagged_dmarc=" + this.params.flagged_dmarc);
+        }
         if (this.params.domain) {
             urlParams.push("domain=" + encodeURIComponent(this.params.domain));
         }
@@ -62,6 +65,7 @@ export class DmarcReports extends LitElement {
                         <a class="ml button mr-5" href="#/dmarc-reports?flagged=true">Reports with Problems</a>
                         <a class="button mr-5" href="#/dmarc-reports?flagged_dkim=true">Reports with DKIM Problems</a>
                         <a class="button mr-5" href="#/dmarc-reports?flagged_spf=true">Reports with SPF Problems</a>
+                        <a class="button" href="#/dmarc-reports?flagged_dmarc=true">Reports with DMARC Problems</a>
                     `
                 }
             </div>


### PR DESCRIPTION
My first pull request 🎉
I hope this contributes to the project.
I hope there are no logic errors in the implementation.

Here are my thoughts:
The DMARC quarantine and reject actions only apply when both SPF and DKIM Alignment  fail. 
I added a flag that marks reports where this condition is met.

Right now, a report is flagged if either SPF or DKIM fails, regardless of which record it occurred on.
SPF failures can be normal (e.g., forwarding, missing Return-Path, or HELO not aligning with SPF, Timeout).
DKIM can fail if the message is modified in transit or, for example, due to a DNS timeout.

I want to show Reports with real DMARC failures,cases that actually affect my DMARC policy i.e., SPF and DKIM Policy Fail in the same record. 

I’d be interested in a DMARC Failure Mail Sources view too, ideally with failure percentages. Might be my next PR 😊



<img width="1284" height="157" alt="image" src="https://github.com/user-attachments/assets/99247c58-d796-430c-99f7-a3685b44dadf" />

