### PR TITLE
M365: Fix log levels in docker compose

### DIFF
--- a/ms-365/docker-compose.yml
+++ b/ms-365/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       IMAP_USER: "<replaceme>"
       IMAP_PASSWORD: "<replaceme>"
       HTTP_SERVER_PASSWORD: "<replaceme>"
-      LOG_LEVEL: "WARNING"
+      LOG_LEVEL: "warn"
     ports:
       - 8080:8080
 


### PR DESCRIPTION
If used as is, the docker compose error out with the following error:

error: invalid value 'WARNING' for '--log-level <LOG_LEVEL>': error parsing level: expected one of "error", "warn", "info", "debug", "trace", or a number 1-5

Replace WARNING by warn so that we provide a valid log level.